### PR TITLE
Bulk array deserialization & topic indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 1.3-SNAPSHOT
 
+- Implementing bulk deserialization of arrays
 - Adding an API call to get a message on a topic at a specific index
 
 1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Java Bag Reader changelog
 
+1.3-SNAPSHOT
+
+- Adding an API call to get a message on a topic at a specific index
+
 1.2
 
 - Removing hard-coded GPS and vehicle name topics

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.github.swri-robotics</groupId>
     <artifactId>bag-reader-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.2</version>
+    <version>1.3-SNAPSHOT</version>
     <name>bag-reader-java</name>
     <url>https://github.com/swri-robotics/bag-reader-java</url>
     <properties>

--- a/src/main/java/com/github/swrirobotics/bags/reader/BagFile.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/BagFile.java
@@ -511,7 +511,8 @@ public class BagFile {
      * @return The message at that position in the bag.
      * @throws BagReaderException If there was an error reading the bag.
      */
-    public MessageType getMessageOnTopicAtIndex(String topic, int index) throws BagReaderException {
+    public MessageType getMessageOnTopicAtIndex(String topic,
+                                                int index) throws BagReaderException {
         topic = topic.trim();
         List<MessageIndex> indexes = myMessageIndexesForTopics.get(topic);
         if (indexes == null) {

--- a/src/main/java/com/github/swrirobotics/bags/reader/BagReader.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/BagReader.java
@@ -34,8 +34,6 @@ import com.github.swrirobotics.bags.reader.exceptions.BagReaderException;
 import com.github.swrirobotics.bags.reader.exceptions.UninitializedFieldException;
 import com.github.swrirobotics.bags.reader.messages.serialization.Float64Type;
 import com.github.swrirobotics.bags.reader.messages.serialization.MessageType;
-import com.github.swrirobotics.bags.reader.messages.serialization.StringType;
-import com.github.swrirobotics.bags.reader.records.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +123,7 @@ public class BagReader {
             // Prints out a unique fingerprint for the bag file.  Note that
             // this is not the same as doing an md5sum of the entire file.
             myLogger.info("Bag fingerprint: " + bag.getUniqueIdentifier());
-
+            
             // Prints some statistics about message deserialization.
             //MessageType.printStats();
         }

--- a/src/main/java/com/github/swrirobotics/bags/reader/BagReader.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/BagReader.java
@@ -123,7 +123,7 @@ public class BagReader {
             // Prints out a unique fingerprint for the bag file.  Note that
             // this is not the same as doing an md5sum of the entire file.
             myLogger.info("Bag fingerprint: " + bag.getUniqueIdentifier());
-            
+
             // Prints some statistics about message deserialization.
             //MessageType.printStats();
         }

--- a/src/main/java/com/github/swrirobotics/bags/reader/messages/serialization/ArrayType.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/messages/serialization/ArrayType.java
@@ -34,6 +34,8 @@ import com.github.swrirobotics.bags.reader.exceptions.UninitializedFieldExceptio
 import com.google.common.collect.Lists;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Timestamp;
 import java.util.List;
 
 /**
@@ -46,6 +48,8 @@ public class ArrayType implements Field {
     private final List<Field> myFields = Lists.newArrayList();
     private String myName;
 
+    private ByteBuffer myData = null;
+
     public ArrayType(Field field, int length) {
         myBaseType = field;
         myLength = length;
@@ -55,7 +59,9 @@ public class ArrayType implements Field {
     /**
      * Used to access the individual fields in the array after
      * {@link #readMessage(ByteBuffer)} has been called.  There will
-     * be one Field object for every value in the array.
+     * be one Field object for every value in the array.  Only call this for
+     * strings and complex message types; primitive types should be accessed
+     * through one of the other "get" methods.
      * @return All of the fields that have been read.
      * @throws UninitializedFieldException If the object has not yet read in data
      *                                     or if a variable-length array had a length of 0.
@@ -66,6 +72,76 @@ public class ArrayType implements Field {
         }
 
         return myFields;
+    }
+
+    public void setOrder(ByteOrder order) {
+        myData = myData.order(order);
+    }
+
+    public byte[] getAsBytes() {
+        byte[] tmp = new byte[myData.capacity()];
+        myData.get(tmp);
+        return tmp;
+    }
+
+    public short[] getAsShorts() {
+        short[] tmp = new short[myData.capacity() / 2];
+        myData.asShortBuffer().get(tmp);
+        return tmp;
+    }
+
+    public int[] getAsInts() {
+        int[] tmp = new int[myData.capacity() / 4];
+        myData.asIntBuffer().get(tmp);
+        return tmp;
+    }
+
+    public long[] getAsLongs() {
+        long[] tmp = new long[myData.capacity() / 8];
+        myData.asLongBuffer().get(tmp);
+        return tmp;
+    }
+
+    public float[] getAsFloats() {
+        float[] tmp = new float[myData.capacity() / 4];
+        myData.asFloatBuffer().get(tmp);
+        return tmp;
+    }
+
+    public double[] getAsDoubles() {
+        double[] tmp = new double[myData.capacity() / 8];
+        myData.asDoubleBuffer().get(tmp);
+        return tmp;
+    }
+
+    public double[] getAsDurations() {
+        int[] intValues = getAsInts();
+        double[] durations = new double[intValues.length/2];
+        for (int i = 0; i < intValues.length; i += 2) {
+            int secs = intValues[0];
+            int nsecs = intValues[1];
+            durations[i/2] = (double)secs + ((double)nsecs) / 1000000000.0;
+        }
+
+        return durations;
+    }
+
+    public Timestamp[] getAsTimestamps() {
+        int[] intValues = getAsInts();
+        Timestamp[] timestamps = new Timestamp[intValues.length/2];
+        for (int i = 0; i < intValues.length; i += 2) {
+            int rawSecs = intValues[0];
+            int rawNsecs = intValues[1];
+
+            long secs = rawSecs >= 0 ? rawSecs : 0x100000000L + rawSecs;
+            long nsecs = rawNsecs >= 0 ? rawNsecs : 0x100000000L + rawNsecs;
+
+            Timestamp val = new Timestamp(secs * 1000);
+            val.setNanos((int) nsecs);
+            timestamps[i/2] = val;
+        }
+
+        return timestamps;
     }
 
     @Override
@@ -79,13 +155,55 @@ public class ArrayType implements Field {
             length = buffer.getInt();
         }
 
-        for(int i = 0; i < length; i++) {
-            // TODO This is probably very slow; it could be optimized by
-            // implementing it individually for each primitive type and
-            // using bulk reads.
-            Field instance = myBaseType.copy();
-            instance.readMessage(buffer);
-            myFields.add(instance);
+        // For most types of data, we know how large they're going to be and
+        // can go ahead and read all of that in and store it in a ByteBuffer;
+        // we can delay deserializing it until it's actually accessed.
+        // For strings and complex message types, the individual items in
+        // the array are variable-length, and we don't know how long the next
+        // one will be until we've examined the first, so we might as well
+        // go ahead and deserialize all of them.
+
+        byte[] tempBytes;
+        switch (myBaseType.getType()) {
+            case "bool":
+            case "byte":
+            case "char":
+            case "int8":
+            case "uint8":
+                tempBytes = new byte[length];
+                buffer.get(tempBytes);
+                myData = ByteBuffer.wrap(tempBytes);
+                break;
+            case "int16":
+            case "uint16":
+                tempBytes = new byte[length * 2];
+                buffer.get(tempBytes);
+                myData = ByteBuffer.wrap(tempBytes);
+                break;
+            case "int32":
+            case "uint32":
+            case "float32":
+                tempBytes = new byte[length * 4];
+                buffer.get(tempBytes);
+                myData = ByteBuffer.wrap(tempBytes);
+                break;
+            case "duration":
+            case "float64":
+            case "int64":
+            case "time":
+            case "uint64":
+                tempBytes = new byte[length * 8];
+                buffer.get(tempBytes);
+                myData = ByteBuffer.wrap(tempBytes);
+                break;
+            default:
+                // strings and other complex messages
+                for(int i = 0; i < length; i++) {
+                    Field instance = myBaseType.copy();
+                    instance.readMessage(buffer);
+                    myFields.add(instance);
+                }
+                break;
         }
     }
 

--- a/src/main/java/com/github/swrirobotics/bags/reader/messages/serialization/MessageCollection.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/messages/serialization/MessageCollection.java
@@ -30,9 +30,9 @@
 
 package com.github.swrirobotics.bags.reader.messages.serialization;
 
-import com.github.swrirobotics.bags.reader.records.Connection;
 import com.github.swrirobotics.bags.reader.exceptions.InvalidDefinitionException;
 import com.github.swrirobotics.bags.reader.exceptions.UnknownMessageException;
+import com.github.swrirobotics.bags.reader.records.Connection;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
@@ -215,7 +215,7 @@ public class MessageCollection {
      * @return A deserializer for the top message type.
      * @throws UnknownMessageException If no deserializer can be found for that message.
      */
-    MessageType getMessageType() throws UnknownMessageException {
+    public MessageType getMessageType() throws UnknownMessageException {
         if (myTopType == null) {
             throw new UnknownMessageException("Unknown");
         }

--- a/src/main/java/com/github/swrirobotics/bags/reader/records/IndexData.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/records/IndexData.java
@@ -46,11 +46,13 @@ public class IndexData {
     private int myConnectionId;
     private int myCount;
     private final List<Index> myIndexes = new ArrayList<>();
+    private final Chunk myChunk;
 
-    public IndexData(Record record) throws BagReaderException {
+    public IndexData(Record record, Chunk chunk) throws BagReaderException {
         myVersion = record.getHeader().getInt("ver");
         myConnectionId = record.getHeader().getInt("conn");
         myCount = record.getHeader().getInt("count");
+        myChunk = chunk;
 
         ByteBuffer buffer = record.getData();
         for (int i = 0; i < myCount; i++) {
@@ -71,6 +73,10 @@ public class IndexData {
 
     public int getCount() {
         return myCount;
+    }
+
+    public Chunk getChunk() {
+        return myChunk;
     }
 
     public List<Index> getIndexes() {


### PR DESCRIPTION
This modifies array deserialization to use bulk operations, which should be much faster.

It also adds a method that will retrieve a message at an arbitrary index within a topic in a bag file.  Unfortunately this is pretty slow, since it actually has to iterate through every message on the topic to find the one you want.
