### PR TITLE
Adding support for LZ4 compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Java Bag Reader changelog
 
+1.4
+
+- Added a custom fork of jpountz/lz4-java that is interoperable with the C++ library
+- Added the ability to deserialize LZ4-compressed chunks
+- Added an API method on BagFile to determine a bag's dominant compression method
+
 1.3
 
 - Implementing bulk deserialization of arrays

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the following dependency to your Maven pom.xml:
 <dependency>
     <groupId>com.github.swri-robotics</groupId>
     <artifactId>bag-reader-java</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.github.swri-robotics</groupId>
     <artifactId>bag-reader-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.3</version>
+    <version>1.4</version>
     <name>bag-reader-java</name>
     <url>https://github.com/swri-robotics/bag-reader-java</url>
     <properties>
@@ -53,6 +53,11 @@
             <artifactId>logback-classic</artifactId>
             <version>1.1.5</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.swri-robotics</groupId>
+            <artifactId>lz4</artifactId>
+            <version>1.4.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/github/swrirobotics/bags/reader/records/ChunkRecordIterator.java
+++ b/src/main/java/com/github/swrirobotics/bags/reader/records/ChunkRecordIterator.java
@@ -34,6 +34,8 @@ import com.github.swrirobotics.bags.reader.BagFile;
 import com.github.swrirobotics.bags.reader.exceptions.BagReaderException;
 import com.github.swrirobotics.bags.reader.records.ChunkInfo;
 import com.github.swrirobotics.bags.reader.records.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.channels.SeekableByteChannel;
 import java.util.Iterator;
@@ -50,6 +52,8 @@ public class ChunkRecordIterator implements Iterator<Record> {
     private final Iterator<ChunkInfo> myChunkIter;
     private final int myConnId;
     private Record myNextRecord = null;
+
+    private static final Logger myLogger = LoggerFactory.getLogger(ChunkRecordIterator.class);
 
     /**
      * Creates the iterator.
@@ -115,6 +119,7 @@ public class ChunkRecordIterator implements Iterator<Record> {
             return chunk;
         }
         catch (BagReaderException e) {
+            myLogger.warn("Error reading data chunk", e);
             return null;
         }
     }


### PR DESCRIPTION
- Added a custom fork of jpountz/lz4-java that is interoperable with the C++ library
- Added the ability to deserialize LZ4-compressed chunks
- Added an API method on BagFile to determine a bag's dominant compression method
- Releasing version 1.4
