### PR TITLE
Fix Travis CI link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Java Bag Reader   [![Build Status](https://travis-ci.org/swri-robotics/bag-reader-java.svg?branch=master)](https://travis-ci.org/swri-robotics/bag-reader-jav)
+# Java Bag Reader   [![Build Status](https://travis-ci.org/swri-robotics/bag-reader-java.svg?branch=master)](https://travis-ci.org/swri-robotics/bag-reader-java)
 
 This is a Java library intended for reading information from and deserializing [ROS Bag Files](http://wiki.ros.org/Bags).
 


### PR DESCRIPTION
Was missing an "a".
